### PR TITLE
Fix bug for input datatype

### DIFF
--- a/R/hdp_quick_init.R
+++ b/R/hdp_quick_init.R
@@ -25,7 +25,7 @@
 hdp_quick_init <- function(data, initcc=2, alphaa=1, alphab=1){
 
   # input checks
-  if (!class(data) %in% c("matrix", "data.frame")) {
+  if (all(!class(data) %in% c("matrix", "data.frame"))) {
     stop("data must be data.frame or matrix")
   }
   if (any(data %% 1 != 0) | any(data < 0)) {

--- a/R/hdp_setdata.R
+++ b/R/hdp_setdata.R
@@ -33,7 +33,7 @@ hdp_setdata <- function(hdp, dpindex, data){
     stop("dpindex must be positive integers no greater than
          numdp(hdp) with no duplicates")
   }
-  if (!class(data) %in% c("matrix", "data.frame")) {
+  if (all(!class(data) %in% c("matrix", "data.frame"))) {
     stop("data must be data.frame or matrix")
   }
   if (nrow(data)!=length(dpindex)) stop("nrow(data) must equal length(dpindex)")


### PR DESCRIPTION
In the existing code, when the `class(data)` is a matrix, the condition of the if statement becomes `(FALSE, TRUE)`, and in the case of data.frame, the condition of the if statement becomes `(TRUE, FASLE)`, causing problems such as this [issue](https://github.com/nicolaroberts/hdp/issues/3#issue-1655623518).

Therefore, `all` is added to return `TRUE` when the condition of the if statement is `(TRUE,TRUE)`, that is, when `class(data)` is **not** data.frame or matrix.




